### PR TITLE
feat: Receiver.receiveを取得するまでブロックするように変更

### DIFF
--- a/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/communications/TCPSocket.java
+++ b/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/communications/TCPSocket.java
@@ -9,7 +9,8 @@ import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import jp.ac.metro_cit.adv_prog_2024.gomoku.interfaces.Receiver;
 import jp.ac.metro_cit.adv_prog_2024.gomoku.interfaces.Sender;
@@ -58,8 +59,8 @@ public class TCPSocket implements Sender, Receiver {
   private ObjectInputStream ois = null;
 
   // スレッドセーフなQueueで送られてきたデータを保持する
-  private final ConcurrentLinkedQueue<GameState> gameStates = new ConcurrentLinkedQueue<>();
-  private final ConcurrentLinkedQueue<GameMessage> messages = new ConcurrentLinkedQueue<>();
+  private final LinkedBlockingQueue<GameState> gameStates = new LinkedBlockingQueue<>();
+  private final LinkedBlockingQueue<GameMessage> messages = new LinkedBlockingQueue<>();
 
   public TCPSocket(TCPSocketProps props) {
     // 渡された引数がTCPSocket用のものであるかを検証
@@ -202,14 +203,19 @@ public class TCPSocket implements Sender, Receiver {
   }
 
   @Override
-  public GameMessage receive() {
+  public GameMessage receive() throws InterruptedException {
     // messagesのQueueから先頭の要素を取得し削除
-    return messages.poll();
+    return messages.take();
   }
 
   @Override
-  public GameState receiveState() {
+  public GameMessage receive(long timeout) throws InterruptedException {
+    return messages.poll(timeout, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public GameState receiveState() throws InterruptedException {
     // gameStatesのQueueから先頭の要素を取得し削除
-    return gameStates.poll();
+    return gameStates.take();
   }
 }

--- a/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/interfaces/Receiver.java
+++ b/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/interfaces/Receiver.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import jp.ac.metro_cit.adv_prog_2024.gomoku.models.GameMessage;
 import jp.ac.metro_cit.adv_prog_2024.gomoku.models.GameState;
+import javax.annotation.Nullable;
 
 /**
  * 通信を受信する側のインターフェイス
@@ -19,7 +20,19 @@ public interface Receiver {
    *
    * @return 相手から送られてきたデータ
    */
-  GameMessage receive();
+  GameMessage receive() throws InterruptedException;
+
+  /**
+   * 相手から送られてきた{@link GameMessage}を取得する
+   * 指定されたタイムアウト(ミリ秒)以内に取得できない場合はnullを返す
+   *
+   * <p>送られてきたデータがない場合はnullを返す
+   *
+   * @param timeout 取得までのタイムアウト(ミリ秒)
+   * @return 相手から送られてきたデータ
+   */
+  @Nullable
+  GameMessage receive(long timeout) throws InterruptedException;
 
   /**
    * 相手から送られてきた{@link GameState}を取得する
@@ -28,7 +41,7 @@ public interface Receiver {
    *
    * @return 相手から送られてきたデータ
    */
-  GameState receiveState();
+  GameState receiveState() throws InterruptedException;
 
   /**
    * Receiverを初期化し、通信を行う準備をする

--- a/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/interfaces/Receiver.java
+++ b/app/src/main/java/jp/ac/metro_cit/adv_prog_2024/gomoku/interfaces/Receiver.java
@@ -1,10 +1,10 @@
 package jp.ac.metro_cit.adv_prog_2024.gomoku.interfaces;
 
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 import jp.ac.metro_cit.adv_prog_2024.gomoku.models.GameMessage;
 import jp.ac.metro_cit.adv_prog_2024.gomoku.models.GameState;
-import javax.annotation.Nullable;
 
 /**
  * 通信を受信する側のインターフェイス
@@ -24,7 +24,8 @@ public interface Receiver {
 
   /**
    * 相手から送られてきた{@link GameMessage}を取得する
-   * 指定されたタイムアウト(ミリ秒)以内に取得できない場合はnullを返す
+   *
+   * <p>指定されたタイムアウト(ミリ秒)以内に取得できない場合はnullを返す
    *
    * <p>送られてきたデータがない場合はnullを返す
    *

--- a/app/src/test/java/jp/ac/metro_cit/adv_prog_2024/gomoku/CommunicationTest.java
+++ b/app/src/test/java/jp/ac/metro_cit/adv_prog_2024/gomoku/CommunicationTest.java
@@ -54,7 +54,7 @@ public class CommunicationTest {
 
   /** センダー・レシーバー間でデータのやり取りが行えることを確認する */
   @Test
-  void initCommunication() {
+  void initCommunication() throws InterruptedException {
     TCPSocketProps senderProps = new TCPSocketProps(null, 5003);
     TCPSocket sender = new TCPSocket(senderProps);
     Assertions.assertDoesNotThrow(sender::initSender);
@@ -79,8 +79,7 @@ public class CommunicationTest {
 
     Assertions.assertEquals("Hello", receiver.receiveState().data());
     Assertions.assertEquals("Hello", receiver.receive().message());
-    Assertions.assertNull(receiver.receiveState());
-    Assertions.assertNull(receiver.receive());
+    Assertions.assertNull((receiver.receive(3000)));
 
     System.out.println("Check receiver -> sender");
     Assertions.assertDoesNotThrow(() -> receiver.send(new GameState("Hello")));
@@ -91,8 +90,7 @@ public class CommunicationTest {
 
     Assertions.assertEquals("Hello", sender.receiveState().data());
     Assertions.assertEquals("Hello", sender.receive().message());
-    Assertions.assertNull(sender.receiveState());
-    Assertions.assertNull(sender.receive());
+    Assertions.assertNull((sender.receive(3000)));
 
     System.out.println("Disconnect");
     Assertions.assertDoesNotThrow(receiver::disconnect);


### PR DESCRIPTION
本PRでは以下の機能を追加します。

- Receiver.receive()時に取得できるまでブロック

そのため、Receiverからデータを取得する際には以下のように記載してください。

```java
public void someMethod(Receiver receiver) {
    // データを取得
    var someData = receiver.receive(); // データが取得できるまでスレッドをブロックします
    var someData2 = receiver.receive(1000); // 時間制限をつける場合には引数にミリ秒でタイムアウトを指定してください
}
```