### PR TITLE
ci: :zap: Spotbugsが失敗してもCIが終了しないように

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Spotbugs
         run: ./gradlew spotbugsMain spotbugsTest
+        continue-on-error: true
 
       - name: Set up reviewdog
         uses: reviewdog/action-setup@v1


### PR DESCRIPTION
## 概要

Spotbugsがエラーを吐いたときにCIが終了してエラーの内容がわからない状態なのを直しました。