### PR TITLE
ci: :zap: 最新の状態のCIのみを実行するように

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - release/*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spotless:
     runs-on: arc-runner-set

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: arc-runner-set


### PR DESCRIPTION
## 概要

- resolve: #67 
- コンカレンシーの設定で最新のコミットでのCI以外は止めるようにした